### PR TITLE
Add experimental.globalFetch support to bypass CORS

### DIFF
--- a/dat.json
+++ b/dat.json
@@ -4,5 +4,8 @@
   "description": "Read dat:// RSS feeds",
   "createdBy": {
     "url": "beaker://shell-window"
+  },
+  "experimental": {
+    "apis": ["globalFetch"]
   }
 }

--- a/lib/store/sources.js
+++ b/lib/store/sources.js
@@ -52,6 +52,8 @@ module.exports = (state, emitter) => {
 }
 
 async function readSource (url) {
+  var fetch = window.experimental && window.experimental.globalFetch || window.globalFetch || fetch
+  
   // read the file content
   var res = await fetch(url)
   var feedContent = await res.text()

--- a/lib/store/sources.js
+++ b/lib/store/sources.js
@@ -52,10 +52,10 @@ module.exports = (state, emitter) => {
 }
 
 async function readSource (url) {
-  var fetch = window.experimental && window.experimental.globalFetch || window.globalFetch || fetch
+  var _fetch = window.experimental && window.experimental.globalFetch || window.globalFetch || window.fetch
   
   // read the file content
-  var res = await fetch(url)
+  var res = await _fetch(url)
   var feedContent = await res.text()
   // var urlp = new URL(url)
   // var archive = new DatArchive(await DatArchive.resolveName(urlp.hostname))


### PR DESCRIPTION
Attempts to load [experimental.globalFetch](https://beakerbrowser.com/docs/apis/experimental-globalfetch) if it exists in order to bypass CORS and allow loading feeds from places like github.

Fixes #1 