### PR TITLE
Fix item sorting in Atom feeds

### DIFF
--- a/lib/store/sources.js
+++ b/lib/store/sources.js
@@ -34,7 +34,7 @@ module.exports = (state, emitter) => {
       source.feed = await readSource(sourceUrl)
       source.feed.items.forEach(item => {
         item.source = source
-        item.pubdate = moment(item.pubdate)
+        item.pubdate = moment(item.pubdate || item.published || item.updated)
       })
     } catch (e) {
       console.error('Error loading feed', source, e)

--- a/lib/store/sources.js
+++ b/lib/store/sources.js
@@ -34,7 +34,7 @@ module.exports = (state, emitter) => {
       source.feed = await readSource(sourceUrl)
       source.feed.items.forEach(item => {
         item.source = source
-        item.pubdate = moment(item.pubdate || item.published || item.updated)
+        item.pubdate = moment(item.pubdate || item.published || item.updated || source.feed.lastBuildDate || source.feed.updated)
       })
     } catch (e) {
       console.error('Error loading feed', source, e)


### PR DESCRIPTION
Atom uses atom:published (optional but same meaning ass rss2:pubdate) and atom:updated (required).

Fallback to using the feed generation time (date the feed was last built) if an item doesn’t have an identifiable date of its own.